### PR TITLE
Client on-peer-leave behavior removes appropriate DOM video nodes.

### DIFF
--- a/static/js/3DComponents/otherPlayerUpdates.js
+++ b/static/js/3DComponents/otherPlayerUpdates.js
@@ -48,10 +48,11 @@ var createPlayerCube = function(ID, createTranslation){
 
 
 var removePlayer = function(ID){
-
   var player = scene.getObjectByName('player-'+ID);
   scene.remove(player);
-
+  var remotesContainer = document.getElementById('remotesVideos');
+  var remoteVideo = document.getElementById(ID);
+  remotesContainer.removeChild(remoteVideo);
 };
 
 var teleportPlayer = function(ID, translation){

--- a/static/js/webRTCComponents/webRTCMain.js
+++ b/static/js/webRTCComponents/webRTCMain.js
@@ -76,6 +76,8 @@ var initWebRTC = function(clientID){
       console.log('data object from channel message');
       console.log(data);
       updateCubeWithVideo(peer.id+'_video_incoming', data.payload);
+      //add clientID to DOM video node
+      document.getElementById(peer.id+'_video_incoming').setAttribute("id", data.payload);
     }
   });
 


### PR DESCRIPTION
DOM video node now gets clientID added as an ID. 
On peer leave, that node is removed from the DOM.